### PR TITLE
PHP 7.2 type warning patch

### DIFF
--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -1178,7 +1178,7 @@ class ReportService
         $querySeparator = "?";
         $reportQueryParameters = $this->getReportQueryParameters();
 
-        if ($reportQueryParameters) {
+        if (strlen($reportQueryParameters) > 0) {
             $httpRequestUri = implode(CoreConstants::SLASH_CHAR, array('company', $this->serviceContext->realmId, $urlResource, $reportName, $querySeparator));
             $httpRequestUri .=  $reportQueryParameters;
         } else {

--- a/src/ReportService/ReportService.php
+++ b/src/ReportService/ReportService.php
@@ -1015,7 +1015,7 @@ class ReportService
     private function getReportQueryParameters()
     {
         $uriParameterList = array();
-        $uriParameterString = null;
+        $uriParameterString = '';
 
         if (!is_null($this->report_date)) {
             array_push($uriParameterList, array("report_date", $this->getReportDate()));
@@ -1156,7 +1156,7 @@ class ReportService
 
 
         foreach ($uriParameterList as $uriParameter) {
-            if (sizeof($uriParameterString) > 0) {
+            if (strlen($uriParameterString) > 0) {
                 $uriParameterString .= "&";
             }
             $uriParameterString .= $uriParameter[0];


### PR DESCRIPTION
Here exception http://prntscr.com/k5z7br

- sizeof should be replaced with strlen. http://php.net/manual/en/function.count.php used for array or \Countable implementation not for string.
- $uriParameterString init value should be empty string not null because you're used append operator.